### PR TITLE
No dummy product for GW & LegacySurvey; changeable ext_id for js9

### DIFF
--- a/astrooda.module
+++ b/astrooda.module
@@ -302,6 +302,7 @@ function astrooda_main_block_content()
 
     $core_module_name = pathinfo(__FILE__, PATHINFO_FILENAME);
     $astrooda_js_settings[$instrument_name]['enable_use_catalog'] = isset($astrooda_settings['instruments'][$instrument_name]['enable_use_catalog']) ? $astrooda_settings['instruments'][$instrument_name]['enable_use_catalog'] : true;
+    $astrooda_js_settings[$instrument_name]['js9_ext_id'] = isset($astrooda_settings['instruments'][$instrument_name]['js9_ext_id']) ? $astrooda_settings['instruments'][$instrument_name]['js9_ext_id'] : 4;
   }
   drupal_add_js(array(
     $core_module_name => $astrooda_js_settings

--- a/instruments/astrooda_gw/astrooda_gw.inc
+++ b/instruments/astrooda_gw/astrooda_gw.inc
@@ -30,27 +30,8 @@ function astrooda_gw($form, &$form_state)
   $instrument_defaults = $astrooda_settings['instruments']['gw'];
 
   $form['query_type'] = array(
-    '#type' => 'select',
-    '#title' => t("Query Type"),
-    '#description' => t("Select query type"),
-    '#default_value' => $instrument_defaults['query_type'],
-    '#options' => array(
-      'Real' => 'Real',
-      'Dummy' => 'Dummy'
-    ),
-    '#parent_classes' => array(
-      'form-group',
-      'col-md-6'
-    ),
-    '#label_classes' => array(
-      'control-label'
-    ),
-    '#attributes' => array(
-      'class' => array(
-        'form-control'
-      )
-    ),
-    '#prefix' => '<div class="row">',
+    '#type' => 'hidden',
+    '#value' => $instrument_defaults['query_type'],
   );
 
   $form['detector'] = array(
@@ -75,6 +56,7 @@ function astrooda_gw($form, &$form_state)
       'L1' => 'L1',
       'V1' => 'V1'
     ),
+    '#prefix' => '<div class="row">',
     '#suffix' => '</div><hr class="hr-default" />'
   );
 

--- a/instruments/astrooda_legacysurvey/astrooda_legacysurvey.inc
+++ b/instruments/astrooda_legacysurvey/astrooda_legacysurvey.inc
@@ -65,7 +65,7 @@ function astrooda_legacysurvey($form, &$form_state)
       'control-label'
     ),
     '#attributes' => array(
-      'name' => $mform_id . 'detector',
+      'name' => $mform_id . 'data_release',
       'class' => array(
         'form-control'
       ),
@@ -94,7 +94,7 @@ function astrooda_legacysurvey($form, &$form_state)
     '#default_value' => $instrument_defaults['product_type'],
     '#options' => array(
       'legacy_survey_image' => 'Image',
-      'legacy_survey_spectrum' => 'Spectrum',
+      'legacy_survey_photometry' => 'Photometry',
     ),
     '#parent_classes' => array(
       'form-group',
@@ -133,13 +133,13 @@ function astrooda_legacysurvey($form, &$form_state)
     '#states' => array(
       'visible' => array(
         ':input[name="' . $mform_id . 'product_type"]' => array(
-          'value' => 'legacy_survey_spectrum'
+          'value' => 'legacy_survey_photometry'
         )
       ),
       'enabled' => array(
         ':input[name="' . $mform_id . 'product_type"]' => array(
           array(
-            'value' => 'legacy_survey_spectrum'
+            'value' => 'legacy_survey_photometry'
           )
         )
       )

--- a/instruments/astrooda_legacysurvey/astrooda_legacysurvey.inc
+++ b/instruments/astrooda_legacysurvey/astrooda_legacysurvey.inc
@@ -30,27 +30,8 @@ function astrooda_legacysurvey($form, &$form_state)
   $instrument_defaults = $astrooda_settings['instruments']['legacysurvey'];
 
   $form['query_type'] = array(
-    '#type' => 'select',
-    '#title' => t("Query Type"),
-    '#description' => t("Select query type"),
-    '#default_value' => $instrument_defaults['query_type'],
-    '#options' => array(
-      'Real' => 'Real',
-      'Dummy' => 'Dummy'
-    ),
-    '#parent_classes' => array(
-      'form-group',
-      'col-md-6'
-    ),
-    '#label_classes' => array(
-      'control-label'
-    ),
-    '#attributes' => array(
-      'class' => array(
-        'form-control'
-      )
-    ),
-    '#prefix' => '<div class="row">',
+    '#type' => 'hidden',
+    '#value' => $instrument_defaults['query_type'],
   );
 
   $form['data_release'] = array(
@@ -81,6 +62,7 @@ function astrooda_legacysurvey($form, &$form_state)
       8 => 'DR8',
       9 => 'DR9'
     ),
+    '#prefix' => '<div class="row">',
     '#suffix' => '</div><hr class="hr-default" />'
   );
 

--- a/instruments/astrooda_legacysurvey/astrooda_legacysurvey.install
+++ b/instruments/astrooda_legacysurvey/astrooda_legacysurvey.install
@@ -47,7 +47,8 @@ function astrooda_legacysurvey_install() {
       'image_band' => 'g',
       'image_size' => 3.,
       'pixel_size' => 1,
-      'acknowledgement' => 'acknowledgement placeholder'
+      'acknowledgement' => 'acknowledgement placeholder',
+      'enable_use_catalog' => FALSE      
   );
 
   $module_name = basename(__FILE__, '.install');

--- a/instruments/astrooda_legacysurvey/astrooda_legacysurvey.install
+++ b/instruments/astrooda_legacysurvey/astrooda_legacysurvey.install
@@ -48,7 +48,8 @@ function astrooda_legacysurvey_install() {
       'image_size' => 3.,
       'pixel_size' => 1,
       'acknowledgement' => 'acknowledgement placeholder',
-      'enable_use_catalog' => FALSE      
+      'enable_use_catalog' => FALSE,
+      'js9_ext_id' => 0      
   );
 
   $module_name = basename(__FILE__, '.install');

--- a/js/astrooda.instrument.js
+++ b/js/astrooda.instrument.js
@@ -2229,10 +2229,11 @@ function panel_title(srcname, param) {
   }
 
   function display_image_js9(image_file_path, data) {
+    var js9_ext_id = Drupal.settings.astrooda[instrument].js9_ext_id;
     var panel_ids = $(".instrument-params-panel",
       ".instrument-panel.active").insert_new_panel(desktop_panel_counter++, 'js9', data.datetime);
     $('#' + panel_ids.panel_body_id).append($('<iframe>', {
-      src: 'dispatch-data/api/v1.0/oda/get_js9_plot?file_path=' + image_file_path + '&ext_id=4',
+      src: 'dispatch-data/api/v1.0/oda/get_js9_plot?file_path=' + image_file_path + '&ext_id=' + js9_ext_id,
       id: 'js9iframe',
       width: '650',
       height: '700',


### PR DESCRIPTION
Hide "product type" field from the form. Also rename LegacySurvey spectrum to photometry. 
Also redo #120 as the change was lost somehow. 

UPD: I also propose a way to relax hard-coded ext_id when showing image in js9.